### PR TITLE
Lec 02: 이미지 사전 로딩

### DIFF
--- a/lecture-2/src/App.js
+++ b/lecture-2/src/App.js
@@ -16,6 +16,10 @@ function App() {
     import("./components/ImageModal").then((ImageModal) => {
       setLazyImageModal(() => ImageModal.default);
     });
+
+    const img = new Image();
+    img.src =
+      "https://stillmed.olympic.org/media/Photos/2016/08/20/part-1/20-08-2016-Football-Men-01.jpg?interpolation=lanczos-none&resize=*:800";
   }, []);
 
   return (


### PR DESCRIPTION
## 주요 변화

- 모달의 첫번째 사진의 용량이 크기 때문에 사전 로딩을 했다.

## 최적화 과정

- ```useEffect```에서 새로운 Image 객체를 생성하고 src 값을 줘서 리소스를 미리 다운로드했다.

## 참고사항

- ```img``` 변수는 직접 사용하기 위해 선언한 게 아니라 리소스 다운로드를 위해서 선언한 변수다. 그래서 약간 코드가 깔끔하지 못하다는 느낌이 드는데 ```img```를 억지로 사용하려고 하면 오히려 코드가 더 더러워질 것 같다는 생각이 든다.
