### PR TITLE
Lec 04: 리덕스 렌더링 최적화

### DIFF
--- a/lecture-4/src/containers/ImageModalContainer.js
+++ b/lecture-4/src/containers/ImageModalContainer.js
@@ -1,23 +1,19 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
+import { shallowEqual, useSelector } from 'react-redux';
 import ImageModal from '../components/ImageModal';
 
 function ImageModalContainer() {
-  const { modalVisible, bgColor, src, alt } = useSelector(state => ({
-    modalVisible: state.imageModal.modalVisible,
-    bgColor: state.imageModal.bgColor,
-    src: state.imageModal.src,
-    alt: state.imageModal.alt,
-  }));
-
-  return (
-    <ImageModal
-      modalVisible={modalVisible}
-      bgColor={bgColor}
-      src={src}
-      alt={alt}
-    />
+  const { modalVisible, bgColor, src, alt } = useSelector(
+    state => ({
+      modalVisible: state.imageModal.modalVisible,
+      bgColor: state.imageModal.bgColor,
+      src: state.imageModal.src,
+      alt: state.imageModal.alt,
+    }),
+    shallowEqual
   );
+
+  return <ImageModal modalVisible={modalVisible} bgColor={bgColor} src={src} alt={alt} />;
 }
 
 export default ImageModalContainer;

--- a/lecture-4/src/containers/PhotoListContainer.js
+++ b/lecture-4/src/containers/PhotoListContainer.js
@@ -10,27 +10,27 @@ function PhotoListContainer() {
     dispatch(fetchPhotos());
   }, [dispatch]);
 
-  // const { category, allPhotos, loading } = useSelector(
+  // const { photos, loading } = useSelector(
   //   state => ({
-  //     category: state.category.category,
-  //     allPhotos: state.photos.data,
+  //     photos:
+  //       state.category.category === 'all'
+  //         ? state.photos.data
+  //         : state.photos.data.filter(photo => photo.category === state.category.category),
   //     loading: state.photos.loading,
   //   }),
   //   shallowEqual
   // );
-  // const photos =
-  //   category === 'all' ? allPhotos : allPhotos.filter(photo => photo.category === category);
 
-  const { photos, loading } = useSelector(
+  const { category, allPhotos, loading } = useSelector(
     state => ({
-      photos:
-        state.category.category === 'all'
-          ? state.photos.data
-          : state.photos.data.filter(photo => photo.category === state.category.category),
+      category: state.category.category,
+      allPhotos: state.photos.data,
       loading: state.photos.loading,
     }),
     shallowEqual
   );
+  const photos =
+    category === 'all' ? allPhotos : allPhotos.filter(photo => photo.category === category);
 
   if (loading === 'error') {
     return <span>Error!</span>;

--- a/lecture-4/src/containers/PhotoListContainer.js
+++ b/lecture-4/src/containers/PhotoListContainer.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import PhotoList from '../components/PhotoList';
 import { fetchPhotos } from '../redux/photos';
 
@@ -10,15 +10,16 @@ function PhotoListContainer() {
     dispatch(fetchPhotos());
   }, [dispatch]);
 
-  const { photos, loading } = useSelector(state => ({
-    photos:
-      state.category.category === 'all'
-        ? state.photos.data
-        : state.photos.data.filter(
-            photo => photo.category === state.category.category
-          ),
-    loading: state.photos.loading,
-  }));
+  const { category, allPhotos, loading } = useSelector(
+    state => ({
+      category: state.category.category,
+      allPhotos: state.photos.data,
+      loading: state.photos.loading,
+    }),
+    shallowEqual
+  );
+  const photos =
+    category === 'all' ? allPhotos : allPhotos.filter(photo => photo.category === category);
 
   if (loading === 'error') {
     return <span>Error!</span>;

--- a/lecture-4/src/containers/PhotoListContainer.js
+++ b/lecture-4/src/containers/PhotoListContainer.js
@@ -10,16 +10,27 @@ function PhotoListContainer() {
     dispatch(fetchPhotos());
   }, [dispatch]);
 
-  const { category, allPhotos, loading } = useSelector(
+  // const { category, allPhotos, loading } = useSelector(
+  //   state => ({
+  //     category: state.category.category,
+  //     allPhotos: state.photos.data,
+  //     loading: state.photos.loading,
+  //   }),
+  //   shallowEqual
+  // );
+  // const photos =
+  //   category === 'all' ? allPhotos : allPhotos.filter(photo => photo.category === category);
+
+  const { photos, loading } = useSelector(
     state => ({
-      category: state.category.category,
-      allPhotos: state.photos.data,
+      photos:
+        state.category.category === 'all'
+          ? state.photos.data
+          : state.photos.data.filter(photo => photo.category === state.category.category),
       loading: state.photos.loading,
     }),
     shallowEqual
   );
-  const photos =
-    category === 'all' ? allPhotos : allPhotos.filter(photo => photo.category === category);
 
   if (loading === 'error') {
     return <span>Error!</span>;


### PR DESCRIPTION
## 문제점

- 이미지를 클릭해서 모달을 띄우면, ```PhotoItem``` 컴포넌트에서 ```dispatch```를 통해 ``` imageModal``` 스토어의 상태를 변경한다.
- 이 과정에서 리덕스의 전체적인 상태는 변하고, 이 상태 변화는 리덕스를 구독하고 있는, 즉 ```useSelector```를 사용하고 있는 컴포넌트에 신호를 보낸다.
- 신호를 받은 컴포넌트는 리덕스의 상태 변화에 따라 컴포넌를 리렌더링 한다.
- 그런데 ```useSelector```로 상태를 받아올 때 ```shallowEqual```을 하지 않아서 반환 값이 같은데도 불구하고 리렌더링이 발생한다.
- 또 ```useSelector```로 상태를 받아올 때 이미지를 카테고리에 따라 필터링해서, 매번 새로운 배열이 생성되고 참조값이 달라져서 여기서도 불필요한 리렌더링이 발생한다.

## 최적화 과정

- ```useSelector```로 상태를 받아올 때 ```Equality Function``` 옵션에 ```shallowEqual``` 함수를 주어 객체 얕은 비교를 통해 객체 참조값이 달라도 값이 같으면 리렌더링 되지 않도록 했다.
- 먼저 모든 데이터를 받아온 다음에 데이터를 필터링하여, 필터링을 하더라도 리렌더링이 발생하지 않도록 했다.

## 참고사항

- ```useSelector``` 내부에서 배열을 새로 생성하더라도 내부의 값 자체는 동일하다.
- 하지만 ```shallowEqual```은 객체의 최상위 프로퍼티만 비교하고, ```photos```는 객체를 배열의 원소들로 갖기 때문에 서로 다른 상태로 판단하여 리렌더링이 발생한다.