### PR TITLE
Lec 04: 병목 코드 최적화

### DIFF
--- a/lecture-4/package-lock.json
+++ b/lecture-4/package-lock.json
@@ -15,6 +15,7 @@
         "axios": "^0.21.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-lazyload": "^3.2.0",
         "react-redux": "^7.2.3",
         "react-scripts": "4.0.3",
         "redux": "^4.0.5",
@@ -16250,6 +16251,15 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-lazyload": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-lazyload/-/react-lazyload-3.2.0.tgz",
+      "integrity": "sha512-zJlrG8QyVZz4+xkYZH5v1w3YaP5wEFaYSUWC4CT9UXfK75IfRAIEdnyIUF+dXr3kX2MOtL1lUaZmaQZqrETwgw==",
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0",
+        "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
     },
     "node_modules/react-redux": {
       "version": "7.2.3",
@@ -33244,6 +33254,12 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-lazyload": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-lazyload/-/react-lazyload-3.2.0.tgz",
+      "integrity": "sha512-zJlrG8QyVZz4+xkYZH5v1w3YaP5wEFaYSUWC4CT9UXfK75IfRAIEdnyIUF+dXr3kX2MOtL1lUaZmaQZqrETwgw==",
+      "requires": {}
     },
     "react-redux": {
       "version": "7.2.3",

--- a/lecture-4/package.json
+++ b/lecture-4/package.json
@@ -10,6 +10,7 @@
     "axios": "^0.21.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-lazyload": "^3.2.0",
     "react-redux": "^7.2.3",
     "react-scripts": "4.0.3",
     "redux": "^4.0.5",

--- a/lecture-4/src/components/ImageModal.js
+++ b/lecture-4/src/components/ImageModal.js
@@ -2,28 +2,19 @@ import React from 'react';
 import styled from 'styled-components';
 import Modal from './Modal';
 import { useDispatch } from 'react-redux';
-import { hideModal, setBgColor } from '../redux/imageModal';
-import { getAverageColorOfImage } from '../utils/getAverageColorOfImage';
+import { hideModal } from '../redux/imageModal';
 
 function ImageModal({ modalVisible, src, alt, bgColor }) {
   const dispatch = useDispatch();
-  const onLoadImage = e => {
-    const averageColor = getAverageColorOfImage(e.target);
-    dispatch(setBgColor(averageColor));
-  };
 
   const closeModal = () => {
     dispatch(hideModal());
   };
 
   return (
-    <Modal
-      modalVisible={modalVisible}
-      closeModal={closeModal}
-      bgColor={bgColor}
-    >
+    <Modal modalVisible={modalVisible} closeModal={closeModal} bgColor={bgColor}>
       <ImageWrap>
-        <FullImage crossOrigin="*" src={src} alt={alt} onLoad={onLoadImage} />
+        <FullImage crossOrigin="*" src={src} alt={alt} />
       </ImageWrap>
     </Modal>
   );

--- a/lecture-4/src/components/PhotoItem.js
+++ b/lecture-4/src/components/PhotoItem.js
@@ -2,19 +2,28 @@ import React from 'react';
 import styled from 'styled-components';
 import { useDispatch } from 'react-redux';
 import LazyLoad from 'react-lazyload';
-import { showModal } from '../redux/imageModal';
+import { setBgColor, showModal } from '../redux/imageModal';
+import { getAverageColorOfImage } from '../utils/getAverageColorOfImage';
 
 function PhotoItem({ photo: { urls, alt } }) {
   const dispatch = useDispatch();
 
-  const openModal = () => {
+  const openModal = e => {
     dispatch(showModal({ src: urls.full, alt }));
+
+    const averageColor = getAverageColorOfImage(e.target);
+    dispatch(setBgColor(averageColor));
   };
 
   return (
     <ImageWrap>
       <LazyLoad offset={1000}>
-        <Image src={urls.small + '&t=' + new Date().getTime()} alt={alt} onClick={openModal} />
+        <Image
+          src={urls.small + '&t=' + new Date().getTime()}
+          alt={alt}
+          onClick={openModal}
+          crossOrigin="*"
+        />
       </LazyLoad>
     </ImageWrap>
   );

--- a/lecture-4/src/utils/getAverageColorOfImage.js
+++ b/lecture-4/src/utils/getAverageColorOfImage.js
@@ -1,4 +1,8 @@
+const cache = {};
+
 export function getAverageColorOfImage(imgElement) {
+  if (cache.hasOwnProperty(imgElement.src)) return cache[imgElement.src];
+
   const canvas = document.createElement('canvas');
   const context = canvas.getContext && canvas.getContext('2d');
   const averageColor = {
@@ -31,6 +35,8 @@ export function getAverageColorOfImage(imgElement) {
   averageColor.r = ~~(averageColor.r / count); // ~~ => convert to int
   averageColor.g = ~~(averageColor.g / count);
   averageColor.b = ~~(averageColor.b / count);
+
+  cache[imgElement.src] = averageColor;
 
   return averageColor;
 }

--- a/lecture-4/yarn.lock
+++ b/lecture-4/yarn.lock
@@ -9776,7 +9776,7 @@
     "strip-ansi" "6.0.0"
     "text-table" "0.2.0"
 
-"react-dom@*", "react-dom@^17.0.2", "react-dom@>= 16.8.0":
+"react-dom@*", "react-dom@^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0", "react-dom@^17.0.2", "react-dom@>= 16.8.0":
   "integrity" "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA=="
   "resolved" "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz"
   "version" "17.0.2"
@@ -9799,6 +9799,11 @@
   "integrity" "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA=="
   "resolved" "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz"
   "version" "17.0.1"
+
+"react-lazyload@^3.2.0":
+  "integrity" "sha512-zJlrG8QyVZz4+xkYZH5v1w3YaP5wEFaYSUWC4CT9UXfK75IfRAIEdnyIUF+dXr3kX2MOtL1lUaZmaQZqrETwgw=="
+  "resolved" "https://registry.npmjs.org/react-lazyload/-/react-lazyload-3.2.0.tgz"
+  "version" "3.2.0"
 
 "react-redux@^7.2.3":
   "integrity" "sha512-ZhAmQ1lrK+Pyi0ZXNMUZuYxYAZd59wFuVDGUt536kSGdD0ya9Q7BfsE95E3TsFLE3kOSFp5m6G5qbatE+Ic1+w=="
@@ -9883,7 +9888,7 @@
   optionalDependencies:
     "fsevents" "^2.1.3"
 
-"react@*", "react@^16.8.3 || ^17", "react@^17.0.2", "react@>= 16", "react@>= 16.8.0", "react@17.0.2":
+"react@*", "react@^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0", "react@^16.8.3 || ^17", "react@^17.0.2", "react@>= 16", "react@>= 16.8.0", "react@17.0.2":
   "integrity" "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA=="
   "resolved" "https://registry.npmjs.org/react/-/react-17.0.2.tgz"
   "version" "17.0.2"


### PR DESCRIPTION
## 문제점

- 이미지 모달을 띄울 때 이미지 원본을 다운로드하고, 이미지를 캔버스에 띄워서 평균 픽셀 값을 계산해서 이 값을 배경 색으로 사용하는데, 이것을 처리하는 함수가 지나치게 느리다.

## 최적화 과정

- 먼저 이미 계산한 이미지에 대해서는 메모이제이션 기법을 활용하여 계산된 배경 색을 미리 저장해두고, 두번째 호출 때부터는 계산된 값을 쓰도록 한다.
- 이미지 원본을 다운로드하고 평균 픽셀 값을 계산하는 게 아니라, 이미 다운로드 되어있고 또 크기도 더 작은 썸네일 이미지를 캔버스에 띄워서 평균 픽셀 값을 계산한다.
- ```PhotoItem```에서 모달을 열 때 미리 계산해서 ```dispatch```하고, 기존에 ```ImageModal```에서 계산하던 부분은 제거한다.

## 참고사항

- 캔버스는 브라우저에서 실행되는 HTML 요소이기 때문에 ```crossOrigin```을 허용해줘야 한다.